### PR TITLE
Fix aquila_generate bug in aquila.py when set use_cache to false

### DIFF
--- a/flagai/model/predictor/aquila.py
+++ b/flagai/model/predictor/aquila.py
@@ -55,7 +55,8 @@ def aquila_generate(
                 input_text_mask[:, cur_pos], tokens[:, cur_pos], next_token
             )
             tokens[:, cur_pos] = next_token
-            prev_pos = cur_pos
+            if model.use_cache:
+                prev_pos = cur_pos
         decoded = []
         for i, t in enumerate(tokens.tolist()):
             # cut to max gen len


### PR DESCRIPTION
When use_cache is set to false, the aquila_generate will get the wrong result. 
And 'use_cache' should be false when the model is served for several tasks synchronously, in case the cache will influence each other.

---
name: Pull Request
title: '[PR]'
assignees: 'BAAI-OpenPlatform,ftgreat'

---

### Description
Please describe here what the PR does.

### Checklist
- [x] bug fixed
- [ ] new feature provided
- [ ] documentation updated
- [ ] tests added
