### PR TITLE
Fix env_arg and env_trainer bug while training LoRA for Aquila

### DIFF
--- a/flagai/env_args.py
+++ b/flagai/env_args.py
@@ -165,10 +165,10 @@ class EnvArgs:
         self.parser.add_argument('--bmt_loss_scale', default=bmt_loss_scale, type=float, help='loss scale in bmtrain')
         self.parser.add_argument('--bmt_loss_scale_steps', default=bmt_loss_scale_steps, type=int, help='loss scale steps in bmtrain')
 
-        self.parser.add_argument('--lora', default=lora, help='Use lora')
-        self.parser.add_argument('--lora_r', default=lora_r, help='lora r value')
-        self.parser.add_argument('--lora_alpha', default=lora_alpha, help='lora alpha value')
-        self.parser.add_argument('--lora_dropout', default=lora_dropout, help='lora dropout value')
+        self.parser.add_argument('--lora', default=lora, type=bool, help='Use lora')
+        self.parser.add_argument('--lora_r', default=lora_r, typp=int, help='lora r value')
+        self.parser.add_argument('--lora_alpha', default=lora_alpha, type=float, help='lora alpha value')
+        self.parser.add_argument('--lora_dropout', default=lora_dropout, type=float, help='lora dropout value')
         self.parser.add_argument('--lora_target_modules', default=lora_target_modules, help='lora_target_modules')
         
         ## TODO, Used in caller script, configs will be updated with yaml_config.
@@ -204,6 +204,14 @@ class EnvArgs:
         if args.env_type == "pytorch":
             # not need the "not_call_launch" parameter
             args.not_call_launch = True
-
+        for arg in vars(args):
+            # change string format list to back to python list object
+            value = getattr(args, arg)
+            if isinstance(value, str):
+                value = value.strip("'\"")
+                if value[0] == '[' and value[-1] == ']':
+                    value = value.strip("[] ").replace(" ", "")
+                    value = value.split(",")
+                    setattr(args,arg,value)
         return args
 

--- a/flagai/env_trainer_v1.py
+++ b/flagai/env_trainer_v1.py
@@ -56,7 +56,14 @@ def get_args_list(env_args):
     for arg in args:
         if not arg.startswith("__") and not arg.startswith("_") and arg not in not_need_to_launch_args:
             args_list.append(f"--{arg}")
-            args_list.append(str(getattr(env_args, arg)))
+            if isinstance(getattr(env_args, arg), list):
+                # change list format param to string
+                # avoiding space in cmdline param like:
+                # --lora_target_modules ['wq', 'wv']
+                # this will interprete the wv as another cmdline param
+                args_list.append("'"+str(getattr(env_args, arg))+"'")
+            else:
+                args_list.append(str(getattr(env_args, arg)))
 
     print(f"args list is {args_list}")
     return args_list


### PR DESCRIPTION
---
name: Pull Request
title: 'Fix env_arg and env_trainer bug while training LoRA for Aquila'
assignees: 'BAAI-OpenPlatform,ftgreat'

---

### Description
训练lora的时候如果在EnvArg里加lora_target_modules，调用trainer生成的命令行参数列表元素中间会有空格，shell会把列表后面的参数当作另一个参数，主要修改了env_arg把列表转str时两边加上`'`，并且在读取参数的时候如果参数是字符串，并且周围是`[]`当成列表解析

### Checklist
- [x] bug fixed
- [ ] new feature provided
- [ ] documentation updated
- [ ] tests added
