### PR TITLE
Fixed an accuracy calculation error in test_eval_gsm.py

### DIFF
--- a/examples/Aquila/test/test_eval_gsm.py
+++ b/examples/Aquila/test/test_eval_gsm.py
@@ -44,6 +44,7 @@ def parse_answer_file(answer_file):
     accuracy = 0
     last_number = 0
     should_find_answer = True
+    should_find_reference_answer = False
 
     for i, l in enumerate(lines):
         try:
@@ -52,14 +53,16 @@ def parse_answer_file(answer_file):
         except:
             pass
 
-        if l.startswith('####'):
+        if should_find_reference_answer and l.startswith('####'):
             reference_answer = l.split('####')[1].strip()
             if reference_answer == last_number:
                 accuracy += 1
         elif l.startswith('===== CASE'):
             should_find_answer = True
+            should_find_reference_answer = False
         elif l.startswith('Reference Answer'):
             should_find_answer = False
+            should_find_reference_answer = True
 
     print('Accuracy: ', accuracy / len(gsm8k_test['question']) * 100)
 


### PR DESCRIPTION
---
name: Pull Request
title: 'Fixed an accuracy calculation error in test_eval_gsm.py'
assignees: 'BAAI-OpenPlatform,ftgreat'

---

### Description
After fine-tuning Aquila using the GSM8K training set, the output may contain "####". This causes the output answer to be treated as a reference answer, resulting in an increment of the accuracy variable and causing a calculation error in the final accuracy. 
[![error.png](https://i.postimg.cc/yx4yK908/error.png)](https://postimg.cc/WF8k6d9B)

To resolve this issue, modify the code to only search for "####" in the "Reference Answer" section.

### Checklist
- [x] bug fixed
- [ ] new feature provided
- [ ] documentation updated
- [ ] tests added
